### PR TITLE
Detect broken rubygems

### DIFF
--- a/lib/sass-embedded.rb
+++ b/lib/sass-embedded.rb
@@ -1,4 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+spec = Gem.loaded_specs['sass-embedded']
+platform = spec&.platform
+if platform.is_a?(Gem::Platform) && platform.os == 'linux' && platform.version.nil?
+  update = if Gem.disable_system_update_message
+             'updating Ruby to version 3.2 or later'
+           else
+             "running 'gem update --system' to update RubyGems"
+           end
+  install = if defined?(Bundler)
+              "running 'rm -f Gemfile.lock && bundle install'"
+            else
+              "running 'gem install sass-embedded'"
+            end
+  raise LoadError, "The gemspec for #{spec.name} at #{spec.loaded_from} was broken. " \
+                   "Try #{update}, and then try #{install} to reinstall."
+end
+
 require_relative 'sass/embedded'


### PR DESCRIPTION
As of #172, the check for broken RubyGems based on its version was removed, because Debian patched a known good version to be a broken version, which makes it impossible to accurately block broken RubyGems versions: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1069089.

Since then, there has been a few reports where users installed this gem on a broken RubyGems and hitting issues during runtime. This PR detects a broken gem installation at load time and provides instruction on how to fix the issue.