### PR TITLE
Adding google-protobuff dependency in gemfile always

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 group :development do
   # TODO: https://github.com/protocolbuffers/protobuf/issues/16853
-  gem 'google-protobuf', force_ruby_platform: true if RUBY_PLATFORM.include?('linux-musl')
+  gem 'google-protobuf', force_ruby_platform: RUBY_PLATFORM.include?('linux-musl')
 
   gem 'rake', '>= 13'
   gem 'rspec', '~> 3.13.0'


### PR DESCRIPTION
This should solve #285

For projects that uses sass-embedded gem, this workaround will cause problems with lockfile if the last update before freezing happened in a machine that is not a `*linux-musl`