### PR TITLE
Update google-protobuf requirement from ~> 4.29 to ~> 4.30

### DIFF
--- a/lib/sass/compiler/host/protofier.rb
+++ b/lib/sass/compiler/host/protofier.rb
@@ -112,7 +112,6 @@ module Sass
           when :number
             Number.from_proto(obj)
           when :color
-            obj.to_s if RUBY_ENGINE == 'jruby' # TODO: https://github.com/protocolbuffers/protobuf/issues/18807
             Sass::Value::Color.send(
               :for_space,
               obj.space,

--- a/sass-embedded.gemspec
+++ b/sass-embedded.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
                                  '>= 3.2'
                                end
 
-  spec.add_dependency 'google-protobuf', '~> 4.29'
+  spec.add_dependency 'google-protobuf', '~> 4.30'
 end


### PR DESCRIPTION
Remove workaround for protocolbuffers/protobuf#18807