### PR TITLE
Drop ruby 3.1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,13 +47,12 @@ jobs:
         vm:
           -
         ruby-version:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
           - '4.0'
-          - jruby-9
-          - jruby-10
+          - jruby-10.0
+          - jruby-10.1
           - truffleruby
           - truffleruby+graalvm
         exclude:
@@ -61,8 +60,6 @@ jobs:
             ruby-version: truffleruby
           - os: windows-latest
             ruby-version: truffleruby+graalvm
-          - os: windows-11-arm
-            ruby-version: '3.1'
           - os: windows-11-arm
             ruby-version: '3.2'
           - os: windows-11-arm
@@ -72,9 +69,6 @@ jobs:
           - os: windows-11-arm
             ruby-version: truffleruby+graalvm
         include:
-          - os: ubuntu-latest
-            container:
-              image: docker.io/library/ruby:3.1-alpine
           - os: ubuntu-latest
             container:
               image: docker.io/library/ruby:3.2-alpine

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - '**/*_pb.rb'
     - 'vendor/**/*'
 
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
   NewCops: enable
 

--- a/lib/sass/compiler/session/function_registry.rb
+++ b/lib/sass/compiler/session/function_registry.rb
@@ -71,11 +71,7 @@ module Sass
           @session.backtrace = e.backtrace
           EmbeddedProtocol::InboundMessage::FunctionCallResponse.new(
             id: function_call_request.id,
-            error: if e.respond_to?(:detailed_message)
-                     e.detailed_message(highlight: false)
-                   else # TODO: remove once ruby 3.1 support is dropped
-                     "#{e.message} (#{e.class.name})"
-                   end
+            error: e.detailed_message(highlight: false)
           )
         end
 

--- a/lib/sass/compiler/session/importer_registry.rb
+++ b/lib/sass/compiler/session/importer_registry.rb
@@ -82,11 +82,7 @@ module Sass
           @session.backtrace = e.backtrace
           EmbeddedProtocol::InboundMessage::CanonicalizeResponse.new(
             id: canonicalize_request.id,
-            error: if e.respond_to?(:detailed_message)
-                     e.detailed_message(highlight: false)
-                   else # TODO: remove once ruby 3.1 support is dropped
-                     "#{e.message} (#{e.class.name})"
-                   end
+            error: e.detailed_message(highlight: false)
           )
         end
 
@@ -111,11 +107,7 @@ module Sass
           @session.backtrace = e.backtrace
           EmbeddedProtocol::InboundMessage::ImportResponse.new(
             id: import_request.id,
-            error: if e.respond_to?(:detailed_message)
-                     e.detailed_message(highlight: false)
-                   else # TODO: remove once ruby 3.1 support is dropped
-                     "#{e.message} (#{e.class.name})"
-                   end
+            error: e.detailed_message(highlight: false)
           )
         end
 
@@ -134,11 +126,7 @@ module Sass
           @session.backtrace = e.backtrace
           EmbeddedProtocol::InboundMessage::FileImportResponse.new(
             id: file_import_request.id,
-            error: if e.respond_to?(:detailed_message)
-                     e.detailed_message(highlight: false)
-                   else # TODO: remove once ruby 3.1 support is dropped
-                     "#{e.message} (#{e.class.name})"
-                   end
+            error: e.detailed_message(highlight: false)
           )
         end
 

--- a/lib/sass/exception.rb
+++ b/lib/sass/exception.rb
@@ -12,78 +12,25 @@ module Sass
     # @return [Array<String>]
     attr_reader :loaded_urls
 
-    if Exception.public_method_defined?(:detailed_message, false)
-      # @!visibility private
-      def initialize(message, detailed_message, sass_stack, span, loaded_urls)
-        super(message)
+    # @!visibility private
+    def initialize(message, detailed_message, sass_stack, span, loaded_urls)
+      super(message)
 
-        @detailed_message = detailed_message
-        @sass_stack = sass_stack
-        @span = span
-        @loaded_urls = loaded_urls
-      end
+      @detailed_message = detailed_message
+      @sass_stack = sass_stack
+      @span = span
+      @loaded_urls = loaded_urls
+    end
 
-      # @!visibility private
-      def detailed_message(highlight: nil, **)
-        return super if @detailed_message.nil?
+    # @!visibility private
+    def detailed_message(highlight: nil, **)
+      return super if @detailed_message.nil?
 
-        highlight = Exception.to_tty? if highlight.nil?
+      highlight = Exception.to_tty? if highlight.nil?
 
-        detailed_message = @detailed_message.sub(message, super)
-        detailed_message.gsub!(/\e\[[0-9;]*m/, '') unless highlight
-        detailed_message
-      end
-    else # TODO: remove once ruby 3.1 support is dropped
-      # @!visibility private
-      def initialize(message, detailed_message, sass_stack, span, loaded_urls)
-        super(detailed_message.nil? ? message : detailed_message)
-
-        @message = message
-        @detailed_message = detailed_message
-        @sass_stack = sass_stack
-        @span = span
-        @loaded_urls = loaded_urls
-      end
-
-      # @!visibility private
-      def message
-        return @message if @detailed_message.nil? || @full_message.nil?
-
-        @detailed_message
-      end
-
-      # @!visibility private
-      def detailed_message(highlight: nil, **)
-        highlight = Exception.to_tty? if highlight.nil?
-
-        super_ = if highlight
-                   lines = message.split("\n")
-                   lines[0] += " (\e[1;4m#{self.class.name}\e[m\e[1m)" unless lines.empty?
-                   lines.map { |line| "\e[1m#{line}\e[m" }.join("\n")
-                 else
-                   lines = message.split("\n", 2)
-                   lines[0] += " (#{self.class.name})" unless lines.empty?
-                   lines.join("\n")
-                 end
-
-        return super_ if @detailed_message.nil?
-
-        detailed_message = @detailed_message.sub(message, super_)
-        detailed_message.gsub!(/\e\[[0-9;]*m/, '') unless highlight
-        detailed_message
-      end
-
-      # @!visibility private
-      def full_message(highlight: nil, order: :top, **)
-        highlight = Exception.to_tty? if highlight.nil?
-
-        @full_message = true
-        full_message = super.force_encoding(message.encoding)
-        full_message.gsub!(/\e\[[0-9;]*m/, '') unless highlight
-        full_message
-      ensure
-        @full_message = nil
-      end
+      detailed_message = @detailed_message.sub(message, super)
+      detailed_message.gsub!(/\e\[[0-9;]*m/, '') unless highlight
+      detailed_message
     end
 
     # @return [String]

--- a/lib/sass/fork_tracker.rb
+++ b/lib/sass/fork_tracker.rb
@@ -8,9 +8,6 @@ module Sass
     module_function
 
     if Process.respond_to?(:_fork)
-      # TODO: remove next line once ruby 3.1 support is dropped
-      require 'set' unless defined?(::Set)
-
       SET = Set.new.compare_by_identity
 
       MUTEX = Mutex.new

--- a/sass-embedded.gemspec
+++ b/sass-embedded.gemspec
@@ -34,11 +34,7 @@ Gem::Specification.new do |spec|
     spec.files += Dir['lib/sass/dart-sass/**/*']
   end
 
-  spec.required_ruby_version = if spec.platform == Gem::Platform::RUBY || spec.platform.os != 'linux'
-                                 '>= 3.1'
-                               else
-                                 '>= 3.2'
-                               end
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'google-protobuf', '~> 4.31'
 end

--- a/spec/sass/value/color/constructors.rb
+++ b/spec/sass/value/color/constructors.rb
@@ -15,83 +15,83 @@ module ColorConstructors
     end
   end
 
-  def legacy_rgb(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args))
+  def legacy_rgb(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*))
   end
 
-  def rgb(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'rgb')
+  def rgb(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'rgb')
   end
 
-  def legacy_hsl(hue, saturation, lightness, *args)
-    Sass::Value::Color.new(hue:, saturation:, lightness:, **_alpha_to_kwargs(*args))
+  def legacy_hsl(hue, saturation, lightness, *)
+    Sass::Value::Color.new(hue:, saturation:, lightness:, **_alpha_to_kwargs(*))
   end
 
-  def hsl(hue, saturation, lightness, *args)
-    Sass::Value::Color.new(hue:, saturation:, lightness:, **_alpha_to_kwargs(*args), space: 'hsl')
+  def hsl(hue, saturation, lightness, *)
+    Sass::Value::Color.new(hue:, saturation:, lightness:, **_alpha_to_kwargs(*), space: 'hsl')
   end
 
-  def legacy_hwb(hue, whiteness, blackness, *args)
-    Sass::Value::Color.new(hue:, whiteness:, blackness:, **_alpha_to_kwargs(*args))
+  def legacy_hwb(hue, whiteness, blackness, *)
+    Sass::Value::Color.new(hue:, whiteness:, blackness:, **_alpha_to_kwargs(*))
   end
 
-  def hwb(hue, whiteness, blackness, *args)
-    Sass::Value::Color.new(hue:, whiteness:, blackness:, **_alpha_to_kwargs(*args), space: 'hwb')
+  def hwb(hue, whiteness, blackness, *)
+    Sass::Value::Color.new(hue:, whiteness:, blackness:, **_alpha_to_kwargs(*), space: 'hwb')
   end
 
-  def lab(lightness, a, b, *args) # rubocop:disable Naming/MethodParameterName
-    Sass::Value::Color.new(lightness:, a:, b:, **_alpha_to_kwargs(*args), space: 'lab')
+  def lab(lightness, a, b, *) # rubocop:disable Naming/MethodParameterName
+    Sass::Value::Color.new(lightness:, a:, b:, **_alpha_to_kwargs(*), space: 'lab')
   end
 
-  def oklab(lightness, a, b, *args) # rubocop:disable Naming/MethodParameterName
-    Sass::Value::Color.new(lightness:, a:, b:, **_alpha_to_kwargs(*args), space: 'oklab')
+  def oklab(lightness, a, b, *) # rubocop:disable Naming/MethodParameterName
+    Sass::Value::Color.new(lightness:, a:, b:, **_alpha_to_kwargs(*), space: 'oklab')
   end
 
-  def lch(lightness, chroma, hue, *args)
-    Sass::Value::Color.new(lightness:, chroma:, hue:, **_alpha_to_kwargs(*args), space: 'lch')
+  def lch(lightness, chroma, hue, *)
+    Sass::Value::Color.new(lightness:, chroma:, hue:, **_alpha_to_kwargs(*), space: 'lch')
   end
 
-  def oklch(lightness, chroma, hue, *args)
-    Sass::Value::Color.new(lightness:, chroma:, hue:, **_alpha_to_kwargs(*args), space: 'oklch')
+  def oklch(lightness, chroma, hue, *)
+    Sass::Value::Color.new(lightness:, chroma:, hue:, **_alpha_to_kwargs(*), space: 'oklch')
   end
 
-  def srgb(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'srgb')
+  def srgb(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'srgb')
   end
 
-  def srgb_linear(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'srgb-linear')
+  def srgb_linear(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'srgb-linear')
   end
 
-  def rec2020(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'rec2020')
+  def rec2020(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'rec2020')
   end
 
-  def display_p3(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'display-p3')
+  def display_p3(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'display-p3')
   end
 
-  def display_p3_linear(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'display-p3-linear')
+  def display_p3_linear(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'display-p3-linear')
   end
 
-  def a98_rgb(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'a98-rgb')
+  def a98_rgb(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'a98-rgb')
   end
 
-  def prophoto_rgb(red, green, blue, *args)
-    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*args), space: 'prophoto-rgb')
+  def prophoto_rgb(red, green, blue, *)
+    Sass::Value::Color.new(red:, green:, blue:, **_alpha_to_kwargs(*), space: 'prophoto-rgb')
   end
 
-  def xyz(x, y, z, *args) # rubocop:disable Naming/MethodParameterName
-    Sass::Value::Color.new(x:, y:, z:, **_alpha_to_kwargs(*args), space: 'xyz')
+  def xyz(x, y, z, *) # rubocop:disable Naming/MethodParameterName
+    Sass::Value::Color.new(x:, y:, z:, **_alpha_to_kwargs(*), space: 'xyz')
   end
 
-  def xyz_d50(x, y, z, *args) # rubocop:disable Naming/MethodParameterName
-    Sass::Value::Color.new(x:, y:, z:, **_alpha_to_kwargs(*args), space: 'xyz-d50')
+  def xyz_d50(x, y, z, *) # rubocop:disable Naming/MethodParameterName
+    Sass::Value::Color.new(x:, y:, z:, **_alpha_to_kwargs(*), space: 'xyz-d50')
   end
 
-  def xyz_d65(x, y, z, *args) # rubocop:disable Naming/MethodParameterName
-    Sass::Value::Color.new(x:, y:, z:, **_alpha_to_kwargs(*args), space: 'xyz-d65')
+  def xyz_d65(x, y, z, *) # rubocop:disable Naming/MethodParameterName
+    Sass::Value::Color.new(x:, y:, z:, **_alpha_to_kwargs(*), space: 'xyz-d65')
   end
 end


### PR DESCRIPTION
- Ruby 3.1 was end-of-life as of 2025/03/26.
- JRuby 9.4 was end-of-life as of 2026/06/08: https://www.jruby.org/2026/06/08/jruby-9-4-15-0.html